### PR TITLE
UDP client code

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -195,7 +195,8 @@ TAB_SIZE               = 2
 # will result in a user-defined paragraph with heading "Side Effects:".
 # You can put \n's in the value part of an alias to insert newlines.
 
-ALIASES                =
+ALIASES                += "FIXME=\todo FIXME:"
+ALIASES                += "TODO=\todo TODO:"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding
@@ -799,7 +800,7 @@ INLINE_SOURCES         = YES
 # doxygen to hide any special comment blocks from generated source code
 # fragments. Normal C, C++ and Fortran comments will always remain visible.
 
-STRIP_CODE_COMMENTS    = YES
+STRIP_CODE_COMMENTS    = NO
 
 # If the REFERENCED_BY_RELATION tag is set to YES
 # then for each documented function all documented

--- a/src/Beacon.cpp
+++ b/src/Beacon.cpp
@@ -3,7 +3,7 @@
 Beacon::Beacon( int interval
               , const CryptoIdentity& ci
               , const std::vector<Transport*>& v_tr)
-              : _msg("\4")
+              : _msg("\4\1")
               , _transports(v_tr)
 {
 	ci.our_businesscard()->AppendToString(&_msg);

--- a/src/Beacon.cpp
+++ b/src/Beacon.cpp
@@ -16,5 +16,5 @@ void Beacon::enable() {
 }
 
 void Beacon::operator() (ev::timer& /*w*/, int /*revents*/) {
-	for (auto tr : _transports) tr->broadcast(_msg);
+	for (auto tr : _transports) tr->to_unknown(_msg);
 }

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -35,7 +35,7 @@ Connection::Connection(CryptoIdentity& ci, Path path, ConnectionPool& cp, Interf
 	}
 
 	for (signed int i=path.size()-2; i>=0; --i) {
-		assert(0); // TODO: forwarding requests not supported yet
+		assert(0); /// \TODO forwarding requests not supported yet
 	}
 
 	rq.AppendToString(_request_packet.get());
@@ -143,8 +143,8 @@ void Connection::handle_auth(CryptoIdentity& ci, Interface& iface, const std::st
 		their_connection_pk = c.substr(0,crypto_box_PUBLICKEYBYTES);
 		if ( ! ci.cookies.allowed(their_connection_pk)) return;
 		ci.cookies.blacklist(their_connection_pk);
-		// FIXME: don't accept connections from connection enc keys that may
-		// have been used with the current cookies to avoid session replays
+		/// \FIXME don't accept connections from connection enc keys that may
+		/// have been used with the current cookies to avoid session replays
 		connection_sk = c.substr(crypto_box_PUBLICKEYBYTES);
 		assert(connection_sk.size() == crypto_box_SECRETKEYBYTES);
 	}
@@ -164,7 +164,7 @@ void Connection::handle_auth(CryptoIdentity& ci, Interface& iface, const std::st
 
 	// verify the vouching
 	std::string vouch = message.substr(0, vouchlen);
-	std::string vkey; // FIXME: get from device
+	std::string vkey; /// \FIXME get from device
 	if ( ! dev.open( vouch, nonce, connection_sk
 	               , PkencAlgo::CURVE25519XSALSA20POLY1305, vkey )
 	  || vkey != their_connection_pk) return;

--- a/src/CryptoIdentity.cpp
+++ b/src/CryptoIdentity.cpp
@@ -39,7 +39,7 @@ bool CryptoIdentity::open( const std::string& ct
                          ) const {
 	if ( algo == PkencAlgo::CURVE25519XSALSA20POLY1305 ) {
 		nonce.resize(crypto_box_NONCEBYTES);
-		try { // TODO: remove exceptions
+		try { /// \TODO remove exceptions
 			ret = crypto_box_open( ct, nonce, pk, _secretkey_naclbox );
 			return 1;
 		} catch(...) {

--- a/src/LinkLocalDiscovery.cpp
+++ b/src/LinkLocalDiscovery.cpp
@@ -107,19 +107,16 @@ void LinkLocalDiscovery::read_cb(ev::io& /*w*/, int /*revents*/)
   struct sockaddr_in6 *src = new sockaddr_in6;
   std::memset(src, 0, sizeof(sockaddr_in6));
   ssize_t read = recvfrom(_fd, buf, 1500, 0, reinterpret_cast<sockaddr*>(src), &srclen);
-  if(read != -1)
+  // Set an arbitrary limit on nonexistent servers
+  if(read != -1 && _clients->nonpersistent() < (1<<20))
   {
     auto device = _nm.device(TransportSocket([](const std::string&){return false;},
                                              uid_format(reinterpret_cast<sockaddr*>(src),
                                               srclen)));
-    if(!device) {
+    if(!device)
       _clients->connect(false,
                         std::shared_ptr<sockaddr>(reinterpret_cast<sockaddr*>(src)),
                         srclen);
-      std::cout << device.get() << std::endl;
-    } else {
-      std::cout << "LLD: found" << std::endl;
-    }
   } else {
     std::perror("LinkLocalDiscovery::read_cb");
   }

--- a/src/LinkLocalDiscovery.cpp
+++ b/src/LinkLocalDiscovery.cpp
@@ -1,6 +1,6 @@
 #include "LinkLocalDiscovery.h"
 #include "NetworkMap.h"
-#include "transports/UDPClientTransport.h"
+#include "transports/UDPTransport.h"
 
 #include <sys/types.h>
 #include <ifaddrs.h>
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <iostream>
 
-LinkLocalDiscovery::LinkLocalDiscovery(UDPClientTransport* clients,
+LinkLocalDiscovery::LinkLocalDiscovery(UDPTransport* clients,
                                        const NetworkMap &nm):
     _clients(clients), _nm(nm), _fd(socket(AF_INET6, SOCK_DGRAM, 0))
 {

--- a/src/LinkLocalDiscovery.cpp
+++ b/src/LinkLocalDiscovery.cpp
@@ -55,6 +55,7 @@ LinkLocalDiscovery::LinkLocalDiscovery(UDPClientTransport* clients,
     std::perror("LinkLocalDiscovery::LinkLocalDiscovery: bind");
     close(_fd);
     _fd = -1;
+    return;
   }
 
   struct ipv6_mreq ipv6_request;
@@ -120,9 +121,11 @@ void LinkLocalDiscovery::read_cb(ev::io& /*w*/, int /*revents*/)
         std::cout << ntohs(src->sin6_port) << std::endl;
         _clients->connect(false,
             std::shared_ptr<sockaddr>(reinterpret_cast<sockaddr*>(src)), srclen);
+	return;
       }
     }
   } else {
     std::perror("LinkLocalDiscovery::read_cb");
   }
+  delete src;
 }

--- a/src/LinkLocalDiscovery.cpp
+++ b/src/LinkLocalDiscovery.cpp
@@ -108,19 +108,19 @@ void LinkLocalDiscovery::read_cb(ev::io& /*w*/, int /*revents*/)
   std::memset(src, 0, sizeof(sockaddr_in6));
   ssize_t read = recvfrom(_fd, buf, 1500, 0, reinterpret_cast<sockaddr*>(src), &srclen);
   // Set an arbitrary limit on nonexistent servers
-  if(read != -1 && _clients->nonpersistent() < (1<<20))
-  {
-    auto device = _nm.device(TransportSocket([](const std::string&){return false;},
-                                             uid_format(reinterpret_cast<sockaddr*>(src),
-                                              srclen)));
-    if(!device) {
-      char ip[40];
-      std::cout << "Connecting to [";
-      std::cout << inet_ntop(AF_INET6, src->sin6_addr.s6_addr, ip, 40) << "]:";
-      std::cout << ntohs(src->sin6_port) << std::endl;
-      _clients->connect(false,
-                        std::shared_ptr<sockaddr>(reinterpret_cast<sockaddr*>(src)),
-                        srclen);
+  if(read != -1) {
+    if( _clients->nonpersistent() < 128) {
+      auto device = _nm.device(
+          TransportSocket([](const std::string&){return false;},
+                          uid_format(reinterpret_cast<sockaddr*>(src), srclen)));
+      if(!device) {
+        char ip[40];
+        std::cout << "Connecting to [";
+        std::cout << inet_ntop(AF_INET6, src->sin6_addr.s6_addr, ip, 40) << "]:";
+        std::cout << ntohs(src->sin6_port) << std::endl;
+        _clients->connect(false,
+            std::shared_ptr<sockaddr>(reinterpret_cast<sockaddr*>(src)), srclen);
+      }
     }
   } else {
     std::perror("LinkLocalDiscovery::read_cb");

--- a/src/LinkLocalDiscovery.cpp
+++ b/src/LinkLocalDiscovery.cpp
@@ -113,10 +113,15 @@ void LinkLocalDiscovery::read_cb(ev::io& /*w*/, int /*revents*/)
     auto device = _nm.device(TransportSocket([](const std::string&){return false;},
                                              uid_format(reinterpret_cast<sockaddr*>(src),
                                               srclen)));
-    if(!device)
+    if(!device) {
+      char ip[40];
+      std::cout << "Connecting to [";
+      std::cout << inet_ntop(AF_INET6, src->sin6_addr.s6_addr, ip, 40) << "]:";
+      std::cout << ntohs(src->sin6_port) << std::endl;
       _clients->connect(false,
                         std::shared_ptr<sockaddr>(reinterpret_cast<sockaddr*>(src)),
                         srclen);
+    }
   } else {
     std::perror("LinkLocalDiscovery::read_cb");
   }

--- a/src/LinkLocalDiscovery.cpp
+++ b/src/LinkLocalDiscovery.cpp
@@ -107,7 +107,7 @@ void LinkLocalDiscovery::read_cb(ev::io& /*w*/, int /*revents*/)
   std::memset(src, 0, sizeof(sockaddr_in6));
   ssize_t read = recvfrom(_fd, buf, 1500, 0, reinterpret_cast<sockaddr*>(src), &srclen);
   if(read != -1)
-    _clients->connect(std::shared_ptr<sockaddr>(reinterpret_cast<sockaddr*>(src)),
+    _clients->connect(false, std::shared_ptr<sockaddr>(reinterpret_cast<sockaddr*>(src)),
                       srclen);
   else
     std::perror("LinkLocalDiscovery::read_cb");

--- a/src/LinkLocalDiscovery.cpp
+++ b/src/LinkLocalDiscovery.cpp
@@ -14,8 +14,8 @@
 #include <algorithm>
 #include <iostream>
 
-LinkLocalDiscovery::LinkLocalDiscovery(UDPClientTransport* clients, const PacketHandler &phn):
-    _clients(clients), _phn(phn), _fd(socket(AF_INET6, SOCK_DGRAM, 0))
+LinkLocalDiscovery::LinkLocalDiscovery(UDPClientTransport* clients):
+    _clients(clients), _fd(socket(AF_INET6, SOCK_DGRAM, 0))
 {
   if(_fd == -1)
   {

--- a/src/LinkLocalDiscovery.h
+++ b/src/LinkLocalDiscovery.h
@@ -3,18 +3,18 @@
 
 #include <ev++.h>
 
-class UDPClientTransport;
+class UDPTransport;
 class NetworkMap;
 
 class LinkLocalDiscovery
 {
  public:
-  LinkLocalDiscovery(UDPClientTransport*, const NetworkMap&);
+  LinkLocalDiscovery(UDPTransport*, const NetworkMap&);
   virtual ~LinkLocalDiscovery();
   void enable();
   void read_cb(ev::io&, int);
  private:
-  UDPClientTransport *_clients;
+  UDPTransport *_clients;
   const NetworkMap &_nm;
   int _fd;
   ev::io _read_watcher;

--- a/src/LinkLocalDiscovery.h
+++ b/src/LinkLocalDiscovery.h
@@ -9,13 +9,12 @@ class UDPClientTransport;
 class LinkLocalDiscovery
 {
  public:
-  LinkLocalDiscovery(UDPClientTransport*, const PacketHandler&);
+  LinkLocalDiscovery(UDPClientTransport*);
   virtual ~LinkLocalDiscovery();
   void enable();
   void read_cb(ev::io&, int);
  private:
   UDPClientTransport *_clients;
-  const PacketHandler &_phn;
   int _fd;
   ev::io _read_watcher;
 };

--- a/src/LinkLocalDiscovery.h
+++ b/src/LinkLocalDiscovery.h
@@ -2,22 +2,20 @@
 #define LINKLOCALDISCOVERY_H_
 
 #include "PacketHandler.h"
-
 #include <ev++.h>
-#include <vector>
 
-class Transport;
+class UDPClientTransport;
 
 class LinkLocalDiscovery
 {
  public:
-  LinkLocalDiscovery(std::vector<Transport*>&, const PacketHandler&);
+  LinkLocalDiscovery(UDPClientTransport*, const PacketHandler&);
   virtual ~LinkLocalDiscovery();
   void enable();
   void read_cb(ev::io&, int);
  private:
-  std::vector<Transport*> &_transports;
-  PacketHandler _phn;
+  UDPClientTransport *_clients;
+  const PacketHandler &_phn;
   int _fd;
   ev::io _read_watcher;
 };

--- a/src/LinkLocalDiscovery.h
+++ b/src/LinkLocalDiscovery.h
@@ -1,20 +1,21 @@
 #ifndef LINKLOCALDISCOVERY_H_
 #define LINKLOCALDISCOVERY_H_
 
-#include "PacketHandler.h"
 #include <ev++.h>
 
 class UDPClientTransport;
+class NetworkMap;
 
 class LinkLocalDiscovery
 {
  public:
-  LinkLocalDiscovery(UDPClientTransport*);
+  LinkLocalDiscovery(UDPClientTransport*, const NetworkMap&);
   virtual ~LinkLocalDiscovery();
   void enable();
   void read_cb(ev::io&, int);
  private:
   UDPClientTransport *_clients;
+  const NetworkMap &_nm;
   int _fd;
   ev::io _read_watcher;
 };

--- a/src/NetworkMap.cpp
+++ b/src/NetworkMap.cpp
@@ -33,7 +33,7 @@ void NetworkMap::add(std::shared_ptr<Device>&& dev_p) {
 		_g_device[node] = dev_p;
 	} else {
 		assert(matching_nodes.size() == 1);
-		// TODO: handle the case of mutiple matches; when nodes have merged.
+		/// \TODO handle the case of mutiple matches; when nodes have merged.
 		node = *matching_nodes.begin();
 		for ( const auto& id : _g_device[node]->ids() ) {
 			auto erased = _node_by_id.erase(id);

--- a/src/NetworkMap.h
+++ b/src/NetworkMap.h
@@ -44,7 +44,7 @@ public:
 
 	Path path_to(const Device&) const;
 	// Return the "best" path to the specified Device. Empty if none.
-	
+
 private:
 	lemon::ListGraph _graph;
 	lemon::ListGraph::NodeMap<std::shared_ptr<Device> > _g_device;

--- a/src/NonceGen64.cpp
+++ b/src/NonceGen64.cpp
@@ -2,7 +2,7 @@
 #include <xtea.h>
 #include <randombytes.h>
 #include <cassert>
-// FIXME: where do the endianness dunctions come from?
+/// \FIXME where do the endianness functions come from?
 
 NonceGen64::NonceGen64(std::uint32_t const key[4])
 	: _next(0)

--- a/src/PacketHandler.cpp
+++ b/src/PacketHandler.cpp
@@ -140,8 +140,14 @@ void PacketHandler::operator()(TransportSocket&& ts, std::string&& packet) {
 
 	} else if (tag == 4) { // "Hey, it's /me/ here"
 		auto dev = std::make_shared<Device>();
-		if ( ! dev->parseFrom( packet.substr(1) ) ) return;
+		if ( ! dev->parseFrom( packet.substr(2) ) ) return;
 		std::cout << "Beacon from " << ipv6ify(dev->id()) << std::endl;
+
+		if(packet[1] == '\x01') {
+			std::string response("\x04\x00", 2);
+			_ci.our_businesscard()->AppendToString(&response);
+			ts.send(response);
+		}
 
 		bool relevant = 0;
 		{

--- a/src/Transport.h
+++ b/src/Transport.h
@@ -44,7 +44,7 @@ public:
 	void onPacket(packet_callback);	
 	// Transports start in a dormant state. activate this.
 	virtual void enable() = 0;
-	virtual void broadcast(const std::string&) = 0; // send to all
+	virtual void to_unknown(const std::string&) = 0; // send to all
 
 protected:
 	Transport() = default;

--- a/src/transports/EthernetTransport.cpp
+++ b/src/transports/EthernetTransport.cpp
@@ -105,7 +105,7 @@ void EthernetTransport::pcap_callback(std::uint8_t *data,
   write(fd[1], packet, pcap_header->caplen);
 }
 
-void EthernetTransport::broadcast(const std::string& msg)
+void EthernetTransport::to_unknown(const std::string& msg)
 {
   send(msg, std::string(ETH_ALEN, 0xff));
 }
@@ -123,7 +123,7 @@ bool EthernetTransport::send(const std::string& msg, const std::string& mac)
   return res == 0;
 }
 
-void EthernetTransport::read_cb(ev::io &watcher, int revents)
+void EthernetTransport::read_cb(ev::io& /*watcher*/, int /*revents*/)
 {
   const std::uint8_t *packet;
   pcap_pkthdr *header;

--- a/src/transports/EthernetTransport.h
+++ b/src/transports/EthernetTransport.h
@@ -16,7 +16,7 @@ class EthernetTransport: public Transport
   EthernetTransport(const std::string& device = std::string());
   virtual ~EthernetTransport();
   void enable();
-  void broadcast(const std::string&);
+  void to_unknown(const std::string&);
   bool send(const std::string&, const std::string&);
  private:
   pcap_t *_pcap;

--- a/src/transports/UDPClientTransport.cpp
+++ b/src/transports/UDPClientTransport.cpp
@@ -101,12 +101,12 @@ UDPClientTransport::~UDPClientTransport() {
 }
 
 void UDPClientTransport::enable() {
-  enable(_read_watcher);
+  enable(_read_watcher, _fd);
 }
 
-void UDPClientTransport::enable(ev::io& watcher) {
+void UDPClientTransport::enable(ev::io& watcher, int fd) {
   watcher.set<UDPClientTransport, &UDPClientTransport::read_cb>(this);
-  watcher.start(_fd, ev::READ);
+  watcher.start(fd, ev::READ);
 }
 
 void UDPClientTransport::broadcast(const std::string& payload) {

--- a/src/transports/UDPClientTransport.cpp
+++ b/src/transports/UDPClientTransport.cpp
@@ -94,7 +94,7 @@ void UDPClientTransport::enable() {
 	_read_watcher.start(_fd, ev::READ);
 }
 
-void UDPClientTransport::broadcast(const std::string& buf) {
+void UDPClientTransport::to_unknown(const std::string& buf) {
 	send(buf);
 }
 

--- a/src/transports/UDPClientTransport.cpp
+++ b/src/transports/UDPClientTransport.cpp
@@ -120,7 +120,7 @@ void UDPClientTransport::read_cb(ev::io& w, int /*revents*/) {
   char *buf = new char[1500]; // ethernet MTU size
   sockaddr *addr = reinterpret_cast<sockaddr*>(new sockaddr_storage);
   socklen_t len = sizeof(sockaddr_storage);
-  ssize_t read = recvfrom(_fd, buf, 1500, 0, addr, &len);
+  ssize_t read = recvfrom(w.fd, buf, 1500, 0, addr, &len);
   if(read == -1 && errno != ECONNREFUSED) {
     std::perror("UDPClientTransport::read_cb: recvfrom:");
     std::abort();

--- a/src/transports/UDPClientTransport.cpp
+++ b/src/transports/UDPClientTransport.cpp
@@ -118,8 +118,8 @@ void UDPClientTransport::enable(ev::io& watcher, int fd) {
 
 void UDPClientTransport::to_unknown(const std::string& payload) {
   for(auto c = _unknown.begin(); c != _unknown.end();) {
-    c->first.send(payload);
-    if(c->second != -1 && ++(c->second) > MAX_MISSED_BEACONS) {
+    bool delivered = c->first.send(payload);
+    if(c->second != -1 && (++(c->second) > MAX_MISSED_BEACONS || !delivered)) {
       c = _unknown.erase(c);
       continue;
     }

--- a/src/transports/UDPClientTransport.cpp
+++ b/src/transports/UDPClientTransport.cpp
@@ -11,7 +11,7 @@
 #include <netdb.h>
 #include <unistd.h>
 
-static inline std::string uid_format(sockaddr *addr, socklen_t len) {
+std::string uid_format(sockaddr *addr, socklen_t len) {
   std::string ret;
   if(addr->sa_family == AF_INET) {
     sockaddr_in *addr_in = reinterpret_cast<sockaddr_in*>(addr);

--- a/src/transports/UDPClientTransport.cpp
+++ b/src/transports/UDPClientTransport.cpp
@@ -155,7 +155,7 @@ std::size_t UDPClientTransport::nonpersistent() const
 {
   std::size_t ret = 0;
   for(auto client : _unknown)
-    if(!client.second)
+    if(client.second >= 0)
       ret++;
   return ret;
 }

--- a/src/transports/UDPClientTransport.cpp
+++ b/src/transports/UDPClientTransport.cpp
@@ -142,3 +142,11 @@ void UDPClientTransport::read_cb(ev::io& w, int /*revents*/) {
   delete[] buf;
 }
 
+std::size_t UDPClientTransport::nonpersistent() const
+{
+  std::size_t ret = 0;
+  for(auto client : _unknown)
+    if(!client.second)
+      ret++;
+  return ret;
+}

--- a/src/transports/UDPClientTransport.h
+++ b/src/transports/UDPClientTransport.h
@@ -7,6 +7,7 @@
 #include <sys/socket.h>
 
 #include <unordered_set>
+#include <unordered_map>
 
 class UDPClient {
  public:
@@ -53,6 +54,7 @@ class UDPClientTransport : public Transport {
   ev::io _read_watcher;
   /// Clients that are known to exist but we haven't seen yet.
   std::unordered_set<std::pair<UDPClient, bool>> _unknown;
+  std::unordered_map<UDPClient, int> _timeouts;
 };
 
 std::string uid_format(sockaddr*, socklen_t);

--- a/src/transports/UDPClientTransport.h
+++ b/src/transports/UDPClientTransport.h
@@ -54,5 +54,6 @@ class UDPClientTransport : public Transport {
   std::unordered_set<std::pair<UDPClient, bool>> _unknown;
 };
 
+std::string uid_format(sockaddr*, socklen_t);
 
 #endif // UDPCLIENTTRANSPORT_H_

--- a/src/transports/UDPClientTransport.h
+++ b/src/transports/UDPClientTransport.h
@@ -27,15 +27,20 @@ namespace std {
       return client.hash();
     }
   };
+  template<> struct hash<std::pair<UDPClient, bool>> {
+    hash<string>::result_type operator()(const std::pair<UDPClient, bool>& client) const {
+      return client.first.hash();
+    }
+  };
 }
 
 class UDPClientTransport : public Transport {
  public:
   UDPClientTransport();
-  void connect(const std::string& host, const std::string& port);
-  void connect(const std::string& host, const std::string& port, int fd);
-  void connect(const std::shared_ptr<sockaddr>& addr, socklen_t len);
-  void connect(const std::shared_ptr<sockaddr>& addr, socklen_t len, int fd);
+  void connect(bool, const std::string& host, const std::string& port);
+  void connect(bool, const std::string& host, const std::string& port, int fd);
+  void connect(bool, const std::shared_ptr<sockaddr>& addr, socklen_t len);
+  void connect(bool, const std::shared_ptr<sockaddr>& addr, socklen_t len, int fd);
   virtual ~UDPClientTransport();
   void enable();
   void enable(ev::io&, int);
@@ -46,7 +51,7 @@ class UDPClientTransport : public Transport {
   int _fd;
   ev::io _read_watcher;
   /// Clients that are known to exist but we haven't seen yet.
-  std::unordered_set<UDPClient> _unknown;
+  std::unordered_set<std::pair<UDPClient, bool>> _unknown;
 };
 
 

--- a/src/transports/UDPClientTransport.h
+++ b/src/transports/UDPClientTransport.h
@@ -38,7 +38,7 @@ class UDPClientTransport : public Transport {
   void connect(const std::shared_ptr<sockaddr>& addr, socklen_t len, int fd);
   virtual ~UDPClientTransport();
   void enable();
-  void enable(ev::io&);
+  void enable(ev::io&, int);
   void broadcast(const std::string&);
  private:
   void read_cb(ev::io&, int);

--- a/src/transports/UDPClientTransport.h
+++ b/src/transports/UDPClientTransport.h
@@ -12,7 +12,7 @@ public:
 	UDPClientTransport(struct sockaddr *addr, socklen_t addrlen);
 	~UDPClientTransport();
 	void enable();
-	void broadcast(const std::string&);
+	void to_unknown(const std::string&);
 	bool send(const std::string&);
 	const struct sockaddr* address() const
 	{

--- a/src/transports/UDPClientTransport.h
+++ b/src/transports/UDPClientTransport.h
@@ -45,6 +45,7 @@ class UDPClientTransport : public Transport {
   void enable();
   void enable(ev::io&, int);
   void to_unknown(const std::string&);
+  std::size_t nonpersistent() const;
  private:
   void read_cb(ev::io&, int);
   friend ev::io;

--- a/src/transports/UDPClientTransport.h
+++ b/src/transports/UDPClientTransport.h
@@ -6,7 +6,6 @@
 
 #include <sys/socket.h>
 
-#include <unordered_set>
 #include <unordered_map>
 
 class UDPClient {
@@ -53,8 +52,7 @@ class UDPClientTransport : public Transport {
   int _fd;
   ev::io _read_watcher;
   /// Clients that are known to exist but we haven't seen yet.
-  std::unordered_set<std::pair<UDPClient, bool>> _unknown;
-  std::unordered_map<UDPClient, int> _timeouts;
+  std::unordered_map<UDPClient, int> _unknown;
 };
 
 std::string uid_format(sockaddr*, socklen_t);

--- a/src/transports/UDPServerTransport.cpp
+++ b/src/transports/UDPServerTransport.cpp
@@ -122,6 +122,8 @@ else
 }
 
 UDPServerTransport::~UDPServerTransport() {
+	delete _group[0];
+	delete _group[1];
 	close(_fd);
 }
 

--- a/src/transports/UDPServerTransport.cpp
+++ b/src/transports/UDPServerTransport.cpp
@@ -1,6 +1,6 @@
 // vim: set ts=4 sw=4 :
 #include "UDPServerTransport.h"
-#include "UDPClientTransport.h"
+#include "UDPTransport.h"
 #include <cassert>
 
 #include <sys/types.h>
@@ -15,7 +15,7 @@
 #include <iostream>
 
 UDPServerTransport::
-UDPServerTransport(UDPClientTransport *clients, const std::string& host
+UDPServerTransport(UDPTransport *clients, const std::string& host
                   , const std::string& port)
 	: _clients(clients)
 {

--- a/src/transports/UDPServerTransport.cpp
+++ b/src/transports/UDPServerTransport.cpp
@@ -1,5 +1,6 @@
 // vim: set ts=4 sw=4 :
 #include "UDPServerTransport.h"
+#include "UDPClientTransport.h"
 #include <cassert>
 
 #include <sys/types.h>
@@ -14,8 +15,9 @@
 #include <iostream>
 
 UDPServerTransport::
-UDPServerTransport( const std::string& host
+UDPServerTransport(UDPClientTransport *clients, const std::string& host
                   , const std::string& port)
+	: _clients(clients)
 {
 	struct addrinfo hints, *res;
         std::memset(&hints, 0, sizeof(struct addrinfo));
@@ -123,74 +125,12 @@ UDPServerTransport::~UDPServerTransport() {
 	close(_fd);
 }
 
-bool UDPServerTransport::send(const std::string& buf, const std::shared_ptr<sockaddr>& addr, socklen_t addrlen)
-{
-	return sendto(_fd, buf.c_str(), buf.size(), 0, addr.get(), addrlen) != -1;
-}
-
-void UDPServerTransport::incoming() {
-	char *buf = new char[1500]; // ethernet MTU size
-	std::shared_ptr<sockaddr> addr(reinterpret_cast<struct sockaddr*>(new sockaddr_storage));
-	socklen_t addrlen = sizeof(struct sockaddr_storage);
-	ssize_t read = recvfrom(_fd, buf, 1500, 0, addr.get(), &addrlen);
-	if(read < 0)
-	{
-		std::perror("UDPServerTransport::incoming");
-		std::abort();
-	}
-	auto iter = _who.insert(std::make_pair(addr, addrlen));
-	if(iter.second == false)
-	  addr = iter.first->first;
-
-	std::string addr_UID;
-	if(addr->sa_family == AF_INET)
-		addr_UID = "IPv4"+std::string(reinterpret_cast<char*>(&reinterpret_cast<sockaddr_in*>(addr.get())->sin_addr.s_addr), 4)+std::string(reinterpret_cast<char*>(&reinterpret_cast<sockaddr_in*>(addr.get())->sin_port), 2);
-	else if(addr->sa_family == AF_INET6)
-		addr_UID = "IPv6"+std::string(reinterpret_cast<char*>(reinterpret_cast<sockaddr_in6*>(addr.get())->sin6_addr.s6_addr), 16)+std::string(reinterpret_cast<char*>(&reinterpret_cast<sockaddr_in6*>(addr.get())->sin6_port), 2);
-	else
-		addr_UID = "DGRAM"+std::string(reinterpret_cast<char*>(addr.get()), addrlen);
-
-	_receive_cb(TransportSocket(std::bind(std::mem_fn(&UDPServerTransport::send), this, std::placeholders::_1, addr, addrlen), addr_UID), std::string(buf, read));
-
-	delete[] buf;
-}
-
 void UDPServerTransport::enable() {
-	// setup libev for this transport here with the incoming() from above
-    _read_watcher.set <UDPServerTransport, &UDPServerTransport::read_cb> (this);
-	_read_watcher.start (_fd, ev::READ);
+  _clients->enable(_read_watcher, _fd);
 }
 
-void UDPServerTransport::read_cb(ev::io &w, int revents) {
-	// Callback for libev loop
-	// Calls incoming()
-	UDPServerTransport::incoming();
-}
-
-void UDPServerTransport::broadcast(const std::string& buf) {
-	for (auto& kv : _who)
-		send(buf, kv.first, kv.second);
+void UDPServerTransport::broadcast(const std::string&) {
 	sendto(_fd, nullptr, 0, 0, _group[0], _group_length[0]);
 	if(_group[1])
 		sendto(_fd, nullptr, 0, 0, _group[1], _group_length[1]);
-}
-
-bool UDPServerTransport::compare::operator()(const std::pair<std::shared_ptr<sockaddr>, socklen_t>& a, const std::pair<std::shared_ptr<sockaddr>, socklen_t>& b) {
-  if(a.first->sa_family != b.first->sa_family)
-    return a.first->sa_family < b.first->sa_family;
-  if(a.first->sa_family == AF_INET) {  // IPv4
-    sockaddr_in *addr_a = reinterpret_cast<sockaddr_in*>(a.first.get());
-    sockaddr_in *addr_b = reinterpret_cast<sockaddr_in*>(b.first.get());
-    if(addr_a->sin_addr.s_addr == addr_b->sin_addr.s_addr)
-      return addr_a->sin_port < addr_b->sin_port;
-    return addr_a->sin_addr.s_addr < addr_b->sin_addr.s_addr;
-  } else if(a.first->sa_family == AF_INET6) {  // IPv6
-    sockaddr_in6 *addr_a = reinterpret_cast<sockaddr_in6*>(a.first.get());
-    sockaddr_in6 *addr_b = reinterpret_cast<sockaddr_in6*>(b.first.get());
-    auto res = std::memcmp(addr_a->sin6_addr.s6_addr, addr_b->sin6_addr.s6_addr, sizeof(in6_addr));
-    if(res == 0)
-      return addr_a->sin6_port < addr_b->sin6_port;
-    return res < 0;
-  }
-  return a < b;
 }

--- a/src/transports/UDPServerTransport.h
+++ b/src/transports/UDPServerTransport.h
@@ -15,20 +15,12 @@ public:
 	virtual ~UDPServerTransport();
 
 	void enable();
-	void broadcast(const std::string&);
+	void to_unknown(const std::string&) {};
     bool send(const std::string&, const std::shared_ptr<sockaddr>&, socklen_t);
 
-    class compare
-    {
-	    public:
-    	bool operator()(const std::pair<std::shared_ptr<sockaddr>, socklen_t>&,
-		    const std::pair<std::shared_ptr<sockaddr>, socklen_t>&);
-    };
 private:
     void read_cb(ev::io&, int);
     friend ev::io;
-	void incoming();
-	std::set<std::pair<std::shared_ptr<sockaddr>,socklen_t>, compare> _who;
 	// UDPv6 shares port space with UDPv4
 	struct sockaddr* _group[2];
 	socklen_t _group_length[2];

--- a/src/transports/UDPServerTransport.h
+++ b/src/transports/UDPServerTransport.h
@@ -3,38 +3,28 @@
 
 #include "Transport.h"
 #include <ev++.h>
-#include <set>
 #include <utility>
 #include <memory>
 
 #include <sys/socket.h>
 
+class UDPClientTransport;
+
 class UDPServerTransport : public Transport {
-public:
-	UDPServerTransport(const std::string&, const std::string&);
-	virtual ~UDPServerTransport();
+ public:
+  UDPServerTransport(UDPClientTransport*, const std::string&,
+                     const std::string&);
+  virtual ~UDPServerTransport();
 
-	void enable();
-	void broadcast(const std::string&);
-    bool send(const std::string&, const std::shared_ptr<sockaddr>&, socklen_t);
-
-    class compare
-    {
-	    public:
-    	bool operator()(const std::pair<std::shared_ptr<sockaddr>, socklen_t>&,
-		    const std::pair<std::shared_ptr<sockaddr>, socklen_t>&);
-    };
-private:
-    void read_cb(ev::io&, int);
-    friend ev::io;
-	void incoming();
-	std::set<std::pair<std::shared_ptr<sockaddr>,socklen_t>, compare> _who;
-	// UDPv6 shares port space with UDPv4
-	struct sockaddr* _group[2];
-	socklen_t _group_length[2];
-	packet_callback _handler;
-	int _fd;
-    ev::io _read_watcher;
+  void enable();
+  void broadcast(const std::string&);
+ private:
+  UDPClientTransport *_clients;
+  // UDPv6 shares port space with UDPv4
+  struct sockaddr* _group[2];
+  socklen_t _group_length[2];
+  int _fd;
+  ev::io _read_watcher;
 };
 
 #endif // UDPSERVERTRANSPORT_H_

--- a/src/transports/UDPServerTransport.h
+++ b/src/transports/UDPServerTransport.h
@@ -25,6 +25,6 @@ class UDPServerTransport : public Transport {
   socklen_t _group_length[2];
   int _fd;
   ev::io _read_watcher;
-}
+};
 
 #endif // UDPSERVERTRANSPORT_H_

--- a/src/transports/UDPServerTransport.h
+++ b/src/transports/UDPServerTransport.h
@@ -8,18 +8,18 @@
 
 #include <sys/socket.h>
 
-class UDPClientTransport;
+class UDPTransport;
 
 class UDPServerTransport : public Transport {
  public:
-  UDPServerTransport(UDPClientTransport*, const std::string&,
+  UDPServerTransport(UDPTransport*, const std::string&,
                      const std::string&);
   virtual ~UDPServerTransport();
 
   void enable();
   void to_unknown(const std::string&);
  private:
-  UDPClientTransport *_clients;
+  UDPTransport *_clients;
   // UDPv6 shares port space with UDPv4
   struct sockaddr* _group[2];
   socklen_t _group_length[2];

--- a/src/transports/UDPTransport.h
+++ b/src/transports/UDPTransport.h
@@ -34,14 +34,14 @@ namespace std {
   };
 }
 
-class UDPClientTransport : public Transport {
+class UDPTransport : public Transport {
  public:
-  UDPClientTransport();
+  UDPTransport();
   void connect(bool, const std::string& host, const std::string& port);
   void connect(bool, const std::string& host, const std::string& port, int fd);
   void connect(bool, const std::shared_ptr<sockaddr>& addr, socklen_t len);
   void connect(bool, const std::shared_ptr<sockaddr>& addr, socklen_t len, int fd);
-  virtual ~UDPClientTransport();
+  virtual ~UDPTransport();
   void enable();
   void enable(ev::io&, int);
   void to_unknown(const std::string&);

--- a/src/vindicat.cpp
+++ b/src/vindicat.cpp
@@ -21,7 +21,7 @@ int main (int argc, char** argv) {
 			transports.push_back( new UDPServerTransport(clients, argv[i+1], argv[i+2]) );
 			i += 2;
 		} else if (arg == "-c") {
-			clients->connect(argv[i+1], argv[i+2]);
+			clients->connect(true, argv[i+1], argv[i+2]);
 			i += 2;
 		} else if (arg == "-e") {
 			transports.push_back( new EthernetTransport(argv[i+1]) );

--- a/src/vindicat.cpp
+++ b/src/vindicat.cpp
@@ -15,18 +15,20 @@
 
 int main (int argc, char** argv) {
 	std::vector<Transport*> transports;
+	UDPClientTransport *clients = new UDPClientTransport;
 	for ( int i=1; i<argc; ++i ) { std::string arg(argv[i]);
 		if (arg == "-s") {
 			transports.push_back( new UDPServerTransport(argv[i+1], argv[i+2]) );
 			i += 2;
 		} else if (arg == "-c") {
-			transports.push_back( new UDPClientTransport(argv[i+1], argv[i+2]) );
+			clients->connect(argv[i+1], argv[i+2]);
 			i += 2;
 		} else if (arg == "-e") {
 			transports.push_back( new EthernetTransport(argv[i+1]) );
 			i += 1;
 		} else assert(0);
 	}
+	transports.push_back(clients);
 
 	CryptoIdentity ci;
 	auto our_device = std::make_shared<Device>();
@@ -51,7 +53,7 @@ int main (int argc, char** argv) {
 	PacketHandler phn(nm, ci, cp, iface.get());
 	for (Transport* tr : transports) tr->onPacket(phn);
 	for (Transport* tr : transports) tr->enable();	
-	LinkLocalDiscovery lld(transports, phn);
+	LinkLocalDiscovery lld(clients, phn);
 	lld.enable();
 
 	ev_run (EV_DEFAULT_ 0);	

--- a/src/vindicat.cpp
+++ b/src/vindicat.cpp
@@ -18,7 +18,7 @@ int main (int argc, char** argv) {
 	UDPClientTransport *clients = new UDPClientTransport;
 	for ( int i=1; i<argc; ++i ) { std::string arg(argv[i]);
 		if (arg == "-s") {
-			transports.push_back( new UDPServerTransport(argv[i+1], argv[i+2]) );
+			transports.push_back( new UDPServerTransport(clients, argv[i+1], argv[i+2]) );
 			i += 2;
 		} else if (arg == "-c") {
 			clients->connect(argv[i+1], argv[i+2]);
@@ -53,7 +53,7 @@ int main (int argc, char** argv) {
 	PacketHandler phn(nm, ci, cp, iface.get());
 	for (Transport* tr : transports) tr->onPacket(phn);
 	for (Transport* tr : transports) tr->enable();	
-	LinkLocalDiscovery lld(clients, phn);
+	LinkLocalDiscovery lld(clients);
 	lld.enable();
 
 	ev_run (EV_DEFAULT_ 0);	

--- a/src/vindicat.cpp
+++ b/src/vindicat.cpp
@@ -53,7 +53,7 @@ int main (int argc, char** argv) {
 	PacketHandler phn(nm, ci, cp, iface.get());
 	for (Transport* tr : transports) tr->onPacket(phn);
 	for (Transport* tr : transports) tr->enable();	
-	LinkLocalDiscovery lld(clients);
+	LinkLocalDiscovery lld(clients, nm);
 	lld.enable();
 
 	ev_run (EV_DEFAULT_ 0);	

--- a/src/vindicat.cpp
+++ b/src/vindicat.cpp
@@ -1,5 +1,5 @@
 #include "transports/UDPServerTransport.h"
-#include "transports/UDPClientTransport.h"
+#include "transports/UDPTransport.h"
 #include "transports/EthernetTransport.h"
 #include "PacketHandler.h"
 #include "InterfaceHandler.h"
@@ -35,7 +35,7 @@ private:
 
 int main (int argc, char** argv) {
 	std::vector<Transport*> transports;
-	UDPClientTransport *clients = new UDPClientTransport;
+	UDPTransport *clients = new UDPTransport;
 	for ( int i=1; i<argc; ++i ) { std::string arg(argv[i]);
 		if (arg == "-s") {
 			transports.push_back( new UDPServerTransport(clients, argv[i+1], argv[i+2]) );


### PR DESCRIPTION
- All UDP client handling refactored into a single class
- A single socket is used to connect to UDP servers
- Selective 'Transport::to_unknown'  instead of universal 'Transport::broadcast'
- Mitigate server advertisement flooding by limiting the number of nonpersistent servers to initiate connections simultaneously
- Use timeouts to detect nonresponsive servers.
- Respond to beacons.
- Run destructors on exit.
- Rename UDPClientTransport to UDPTransport
