### PR TITLE
Support for larger packet sizes

### DIFF
--- a/src/IPv6.cpp
+++ b/src/IPv6.cpp
@@ -1,4 +1,5 @@
 #include "IPv6.h"
+#include "Log.h"
 
 #include <arpa/inet.h>
 #include <cstring>
@@ -190,10 +191,9 @@ IPv6::Packet IPv6::Packet::reassemble(const IPv6::Address &src,
 
 IPv6::Packet IPv6::Packet::read(int fd)
 {
-  IPv6::Packet packet(1500);
-  ssize_t bytes = ::read(fd, packet.data(), 1500);
-  if(bytes == -1)
-    throw std::system_error(errno, std::system_category());
+  IPv6::Packet packet(IPv6::Packet::max_packet_size);
+  if(::read(fd, packet.data(), IPv6::Packet::max_packet_size) == -1)
+    FATAL().perror("read");
   assert(packet.version() == 6);
   return packet;
 }

--- a/src/IPv6.h
+++ b/src/IPv6.h
@@ -20,6 +20,7 @@ namespace IPv6
     std::size_t _data_length;
   public:
     const static int header_length = 40;
+    const static int max_packet_size = header_length + (1 << 16) - 1;
     // Allocate storage and set protocol version
     explicit Packet(std::size_t len);
 

--- a/src/TUNInterface.cpp
+++ b/src/TUNInterface.cpp
@@ -45,6 +45,9 @@ std::unique_ptr<TUNInterface> TUNInterface::open(const std::string &device_hash,
   ifr.ifr_flags |= IFF_UP;
   if(ioctl(sockfd, SIOCSIFFLAGS, &ifr) < 0)
     goto socket_error;
+  ifr.ifr_mtu = (1U << 16) - 1;
+  if(ioctl(sockfd, SIOCSIFMTU, &ifr) < 0)
+    goto socket_error;
 
   // Set IPv6 address and netmask
   if(ioctl(sockfd, SIOCGIFINDEX, &ifr) < 0)
@@ -56,7 +59,7 @@ std::unique_ptr<TUNInterface> TUNInterface::open(const std::string &device_hash,
     ret->_address.address[i+1] = ifr6.ifr6_addr.s6_addr[i+1] = device_hash.at(i);
   ifr6.ifr6_prefixlen = 8;
   if(ioctl(sockfd, SIOCSIFADDR, &ifr6) < 0)
-    goto socket_error;  
+    goto socket_error;
   
   close(sockfd);
   


### PR DESCRIPTION
- Support for arbitrary packet sizes in <tt>UDPTransport</tt>.
- Raise the MTU of the TUN interface to 2^16-1 bytes.
