### PR TITLE
Reject IPv6 extension headers. Fix #12

### DIFF
--- a/src/IPv6.cpp
+++ b/src/IPv6.cpp
@@ -24,6 +24,7 @@ IPv6::Packet::Packet(std::size_t len):
   _data(new std::uint8_t[len]), _data_length(len)
 {
   version(6);
+  payload_length(len-header_length);
 }
 
 IPv6::Packet::Packet(const std::uint8_t *packet, std::size_t len):

--- a/src/IPv6.cpp
+++ b/src/IPv6.cpp
@@ -198,3 +198,39 @@ IPv6::Packet IPv6::Packet::read(int fd)
   return packet;
 }
 
+IPv6::Packet IPv6::Packet::generate_ICMPv6(const IPv6::Address& src, 
+    const IPv6::Address& dest, std::uint8_t type, std::uint8_t code,
+    const std::string& payload) {
+  IPv6::Packet packet(IPv6::Packet::header_length+4+payload.size());
+  packet.source(src);
+  packet.destination(dest);
+  packet.next_header(58);
+  packet.payload()[0] = type;
+  packet.payload()[1] = code;
+  packet.payload()[2] = 0;
+  packet.payload()[3] = 0;
+  std::memcpy(packet.payload()+4, payload.data(), payload.size());
+
+  std::uint32_t checksum = 0;
+  for(int i = 0; i < 16; i += 2) {
+    checksum += (src.address[i] << 8) & 0xFF00;
+    checksum += src.address[i+1];
+    checksum += (dest.address[i] << 8) & 0xFF00;
+    checksum += dest.address[i+1];
+  }
+  checksum += packet.payload_length();
+  checksum += 58;
+  std::size_t length = packet.payload_length()/2*2;
+  for(int i = 0; i < length; i += 2) {
+    checksum += (packet.payload()[i] << 8) & 0xFF00;
+    checksum += packet.payload()[i+1];
+  }
+  if(length != packet.payload_length())
+    checksum += (packet.payload()[packet.payload_length()-1] << 8) & 0xFF00;
+  while(checksum >> 16)
+    checksum = (checksum & 0xFFFF) + (checksum >> 16);
+  packet.payload()[2] = ((~checksum) >> 8) & 0xFF;
+  packet.payload()[3] = (~checksum) & 0xFF;
+
+  return packet;
+}

--- a/src/IPv6.h
+++ b/src/IPv6.h
@@ -67,6 +67,10 @@ namespace IPv6
     static Packet reassemble(const Address &src, const Address &dst,
       std::uint8_t next_header, const std::string &payload);
     static Packet read(int fd);
+
+    static Packet generate_ICMPv6(const Address& src, const Address& dest,
+                                  std::uint8_t type, std::uint8_t code,
+                                  const std::string& payload);
   };
 }
 #endif

--- a/src/InterfaceHandler.cpp
+++ b/src/InterfaceHandler.cpp
@@ -31,6 +31,12 @@ void InterfaceHandler::operator()(std::string&& to, std::string&& packet) {
       path = _nm.path_to(*dst_dev);
     }
 
+    if(path.size() == 0) {
+      assert(_nm.device(to)->id() == _nm.our_device().id());
+      _ch(_nm.our_device().id(), packet[0], packet.substr(1));
+      return;
+    }
+
     auto conn = std::make_shared<Connection>(_ci, path, _cp, _ch);
     
     auto rfwd = std::make_shared<SimpleForwarding>(_nm, conn->id());

--- a/src/NetworkMap.cpp
+++ b/src/NetworkMap.cpp
@@ -135,7 +135,8 @@ std::vector< std::shared_ptr<Device> > NetworkMap::devices() {
 std::vector< std::shared_ptr<Device> > NetworkMap::neighbors() {
   std::vector< std::shared_ptr<Device> > ret;
   for (lemon::ListGraph::IncEdgeIt e(_graph, _our_node); e != lemon::INVALID; ++e) {
-    ret.push_back(_g_device[_graph.oppositeNode(_our_node, e)]);
+    if (_graph.oppositeNode(_our_node, e) != _our_node)  // Ignore loops
+      ret.push_back(_g_device[_graph.oppositeNode(_our_node, e)]);
   }
   return ret;
 }


### PR DESCRIPTION
- Reject IPv6 extension headers. (2b474eb)
- Ignore local loops in network graph. (3293df1) Closes #12
- Loop back packets meant for us. (6f59155)
